### PR TITLE
accept any kind of path for Alf::Reader.reader

### DIFF
--- a/lib/alf/reader/class_methods.rb
+++ b/lib/alf/reader/class_methods.rb
@@ -42,10 +42,10 @@ module Alf
       # @return [Reader] a reader instance
       # 
       def reader(filepath, *args)
-        if filepath.is_a?(String)
+        if filepath.respond_to? :to_str or filepath.respond_to? :to_path
           ext = File.extname(filepath)
           if registered = readers.find{|r| r[1].include?(ext)}
-            registered[2].new(filepath, *args)
+            registered[2].new(filepath.to_s, *args)
           else
             raise "No registered reader for #{ext} (#{filepath})"
           end


### PR DESCRIPTION
The documentation should be updated, but I don't speak (yet) YARD, so please teach me.

Pathname use :to_str in 1.8, :to_path in 1.9.
Path now defines both. So checking only :to_str would be enough if you do not plan to accept Pathname.

This is an easy way (because it converts directly to String) to solve the current situation with Viiite.
Alf should ideally support paths everywhere, but Ruby is not really helpful here (there should be a class for paths, which would avoid the confusion between String (potentially IO contents) and paths), and you would need to check like I do here everywhere you use a path.

If used in a case statement, you could probably define something like

``` ruby
KindOfPath = lambda do |path|
  path.respond_to? :to_str or path.respond_to? :to_path
end

case path
-when String
+when KindOfPath
end

-if path.is_a? String
+if KindOfPath === path
```
