### PR TITLE
Remove the unneeded parenthesis for the "-> {}" lambda syntax

### DIFF
--- a/doc/gh-pages/overview/relational-basics.md
+++ b/doc/gh-pages/overview/relational-basics.md
@@ -118,8 +118,8 @@ Relational algebra is similar, but applies to relations. For example:
 #  What are red or heavy parts ?
 #
 (union 
-  (restrict :parts, ->(){ color == Color('red') }),
-  (restrict :parts, ->(){ heavy == true         }))
+  (restrict :parts, ->{ color == Color('red') }),
+  (restrict :parts, ->{ heavy == true         }))
 </code></pre>
 
 Can be rephrased/rewritten as
@@ -127,6 +127,6 @@ Can be rephrased/rewritten as
 <pre class="theory"><code class="ruby">#
 #  What parts are either red or heavy ?
 #
-(restrict :parts, ->(){ (color == Color('red')) or (heavy == true) })
+(restrict :parts, ->{ (color == Color('red')) or (heavy == true) })
 </code></pre>
 

--- a/doc/gh-pages/ruby/index.md
+++ b/doc/gh-pages/ruby/index.md
@@ -22,7 +22,7 @@ Alf implements a Domain Specific Language (DSL), for writing and executing relat
 
 * Ala "ruby -e", for shortest expressions (see also [Using Alf in Shell](shell/index))
 
-<pre><code class="terminal">$ alf -e "(restrict :suppliers, ->(){ city == 'London' })"</code></pre>
+<pre><code class="terminal">$ alf -e "(restrict :suppliers, ->{ city == 'London' })"</code></pre>
 
 * Through .alf files that contain them
 
@@ -32,7 +32,7 @@ Alf implements a Domain Specific Language (DSL), for writing and executing relat
 
 <pre><code class="ruby">require 'alf'
 Alf.lispy.evaluate{
-  (restrict :suppliers, ->(){ city == 'London' })
+  (restrict :suppliers, ->{ city == 'London' })
 }
 </code></pre>
 
@@ -41,7 +41,7 @@ Alf.lispy.evaluate{
 * Alf is not limited to the use of simple scalar types. Attribute can be any ruby class/object implementing a type/value in a consistent way. You also have full Ruby power in expressions:
 
 <pre><code class="ruby">Alf.lispy.evaluate{
-  (restrict :suppliers, ->(){ city =~ /^P/ })
+  (restrict :suppliers, ->{ city =~ /^P/ })
 }</code></pre>
 
 * Alf automatically resolves relation names according to an environment of use. By default, the latter is bound to the examples bundled with Alf. This way, you can learn Alf without worrying about where data come from, or even get it as plain ruby objects:
@@ -70,6 +70,6 @@ puts rel.to_a
 
 * While not idomatic and not recommended, you can also use Alf with an object-oriented style thanks to `Relation`:
 
-<pre><code class="ruby">cities.extend(:bigname => ->(){ city.upcase })</code></pre>
+<pre><code class="ruby">cities.extend(:bigname => ->{ city.upcase })</code></pre>
 
 

--- a/lib/alf/tools/to_lispy.rb
+++ b/lib/alf/tools/to_lispy.rb
@@ -51,12 +51,12 @@ module Alf
         Tools.to_ruby_literal(v.name)
       end
 
-      # TupleExpression -> ->(){ ... }
+      # TupleExpression -> ->{ ... }
       r.upon(Types::TupleExpression) do |v, rd|
-        "->(){ #{v.has_source_code!} }"
+        "->{ #{v.has_source_code!} }"
       end
 
-      # TupleComputation -> { :big => -(){ ... }, ... }
+      # TupleComputation -> { :big => ->{ ... }, ... }
       r.upon(Types::TupleComputation) do |v, rd|
         "{" + v.computation.map{|name,compu|
           [name.inspect, r.coerce(compu)].join(" => ")
@@ -68,7 +68,7 @@ module Alf
         v.has_source_code!
       end
 
-      # Summarization -> { :total => ->(){ ... } }
+      # Summarization -> { :total => ->{ ... } }
       r.upon(Types::Summarization) do |v, rd|
         "{" + v.aggregations.map{|name,compu|
           [name.inspect, r.coerce(compu)].join(" => ")

--- a/spec/unit/alf-core/tools/test_to_lispy.rb
+++ b/spec/unit/alf-core/tools/test_to_lispy.rb
@@ -51,12 +51,12 @@ module Alf
 
       describe "When built from a string" do
         let(:arg){ "status.upcase" }
-        it{ should eq("->(){ status.upcase }")}
+        it{ should eq("->{ status.upcase }")}
       end
 
       describe "When built from a symbol" do
         let(:arg){ :status }
-        it{ should eq("->(){ status }")}
+        it{ should eq("->{ status }")}
       end
 
     end # TupleExpression
@@ -66,37 +66,37 @@ module Alf
 
       describe "When built from a TupleExpression" do
         let(:arg){ TupleExpression.coerce("status > 10") }
-        it{ should eq("->(){ status > 10 }")}
+        it{ should eq("->{ status > 10 }")}
       end
 
       describe "When built from a boolean" do
         let(:arg){ true }
-        it{ should eq("->(){ true }")}
+        it{ should eq("->{ true }")}
       end
 
       describe "When built from a String" do
         let(:arg){ "status > 10" }
-        it{ should eq("->(){ status > 10 }")}
+        it{ should eq("->{ status > 10 }")}
       end
 
       describe "When built from a Hash" do
         let(:arg){ {:status => 10} }
-        it{ should eq("->(){ (self.status == 10) }")}
+        it{ should eq("->{ (self.status == 10) }")}
       end
 
       describe "When built with a singleton Array" do
         let(:arg){ ["status > 10"] }
-        it{ should eq("->(){ status > 10 }")}
+        it{ should eq("->{ status > 10 }")}
       end
 
       describe "When built with a Hash-Array" do
         let(:arg){ ["status", "10"] }
-        it{ should eq("->(){ (self.status == 10) }")}
+        it{ should eq("->{ (self.status == 10) }")}
       end
 
       describe "When built with a Hash-Array without coercion" do
         let(:arg){ [:status, "10"] }
-        it{ should eq("->(){ (self.status == \"10\") }")}
+        it{ should eq("->{ (self.status == \"10\") }")}
       end
 
     end # TuplePredicate
@@ -106,7 +106,7 @@ module Alf
 
       describe "When built from a Hash" do
         let(:arg){ {"upcased" => "status.upcase"} }
-        it{ should eq("{:upcased => ->(){ status.upcase }}")}
+        it{ should eq("{:upcased => ->{ status.upcase }}")}
       end
 
     end # TupleComputation


### PR DESCRIPTION
Hello,

As the title says, I propose to remove the extra "()" in "->(){ ... }" expressions, mostly for the gh-pages.
