### PR TITLE
Fix boolean comparaison

### DIFF
--- a/lib/alf/support/miscellaneous.rb
+++ b/lib/alf/support/miscellaneous.rb
@@ -62,7 +62,7 @@ module Alf
       return 0  if x==y
       return -1 if x.nil?
       return 1  if y.nil?
-      x.respond_to?(:<=>) ? (x <=> y) : (x.to_s <=> y.to_s)
+      x.respond_to?(:<=>) && !([true, false].include? x) ? (x <=> y) : (x.to_s <=> y.to_s)
     end
 
   end # module Support


### PR DESCRIPTION
When an ordering compare booleans, it used the Object '<=>' [operator](http://ruby-doc.org/core-2.2.2/Object.html#method-i-3C-3D-3E). Causing it to return nil when comparing true and false
